### PR TITLE
Swimsuit season

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.0.1
+* Initial commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:5.6-alpine
+MAINTAINER "The Impact Bot" <technology@bcorporation.net>
+
+RUN set -xe; \
+    apk add --no-cache \
+    libmemcached-dev \
+    libmcrypt-dev \
+    autoconf \
+    g++ \
+    make \
+    postgresql-dev \
+    cyrus-sasl-dev \
+    # this version of alpine has postgresql 9.5 by default
+    # TODO remove this dependency
+    build-base \
+    readline-dev \
+    openssl-dev \
+    zlib-dev \
+    libxml2-dev \
+    glib-lang \
+    wget \
+    gnupg \
+    ca-certificates \
+    libssl1.0 && \
+    wget ftp://ftp.postgresql.org/pub/source/v9.4.11/postgresql-9.4.11.tar.bz2 -O /tmp/postgresql-9.4.11.tar.bz2 && \
+    tar xvfj /tmp/postgresql-9.4.11.tar.bz2 -C /tmp && \
+    cd /tmp/postgresql-9.4.11 && ./configure --enable-integer-datetimes --enable-thread-safety --prefix=/usr/local --with-libedit-preferred --with-openssl  && make world && make install world && make -C contrib install && \
+    cd /tmp/postgresql-9.4.11/contrib && make && make install && \
+    apk --purge del build-base wget gnupg ca-certificates && \
+    rm -r /tmp/postgresql-9.4.11*
+
+RUN docker-php-ext-install \
+    json \
+    mcrypt \
+    pdo \
+    pdo_pgsql
+
+RUN pecl install \
+    xdebug \
+    memcached-2.2.0 \
+    && docker-php-ext-enable xdebug memcached
+
+RUN mkdir -p /data/www
+VOLUME ["/data"]
+WORKDIR /data/www
+
+ADD php.ini $PHP_INI_DIR/conf.d/impact.ini
+ENTRYPOINT ["php"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -xe; \
     postgresql-dev \
     cyrus-sasl-dev \
     # this version of alpine has postgresql 9.5 by default
-    # TODO remove this dependency
+    # TODO remove this dependency in the future
     build-base \
     readline-dev \
     openssl-dev \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# impact-platform-php
-Docker container for PHP
+# Impact Platform: PHP
+[Docker](https://www.docker.com/) container for [PHP](http://www.php.net/).
+
+## Overview
+Use with the [data container](https://github.com/b-lab-org/impact-platform-data) and [memcached container](https://github.com/b-lab-org/impact-platform-memcached).
+
+## Docker-Compose Usage
+```
+php:
+    image: impactbot/impact-platform-php
+    entrypoint: php <your php command>
+    volumes_from:
+        - data
+```

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,4 @@
+xdebug.max_nesting_level = 300
+memcached.use_sasl = 1
+upload_max_filesize = 25M
+post_max_size = 25M


### PR DESCRIPTION
This provides a generic `php` image to run php commands. It will make the following images obsolete:
- `impact-platform-artisan` - 258MB
- `impact-platform-codeception` - 612MB

The resulting image will be 285MB, giving us ~600MB of free space. It will be used for:
- artisan
- codeception
- artisan queue

It's largely similar to the `php-fpm` image, but it exposes a port and installs `postgresql`, which is currently needed for data cleanup in our test suite and to run seeder files.

*Note:* The base alpine image comes with `postgresql:9.5`. We use `9.4` in `production`, so there is some extra effort in this image to install the older version.

