### PR TITLE
Adds ncurses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 0.0.2
+* Adding [ncurses](http://php.net/manual/en/book.ncurses.php)
+
 ## 0.0.1
 * Initial commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN set -xe; \
     glib-lang \
     wget \
     gnupg \
+    ncurses \
     ca-certificates \
     libssl1.0 && \
     # this version of alpine has postgresql 9.5 by default

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -xe; \
     ncurses \
     ca-certificates \
     libssl1.0 && \
+    
     # this version of alpine has postgresql 9.5 by default
     # TODO remove this dependency in the future
     wget ftp://ftp.postgresql.org/pub/source/v9.4.11/postgresql-9.4.11.tar.bz2 -O /tmp/postgresql-9.4.11.tar.bz2 && \


### PR DESCRIPTION
Codeception depends on "tput" to get console width, otherwise it's unable to print failed test output.