### PR TITLE
Adding Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.4
+* Adding bash
+
 ## 0.0.3
 * Adding Composer and bzip2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN set -xe; \
     ca-certificates \
     readline \
     bzip2-dev \
+    bash \
     libssl1.0 && \
 
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin && \


### PR DESCRIPTION
This will allow local development + Heroku workers to run the same scripts, instead of having to maintain `ash` + `bash` versions. 